### PR TITLE
Fix compilation and testing

### DIFF
--- a/python-wrapper/pytsa.cpp
+++ b/python-wrapper/pytsa.cpp
@@ -1,5 +1,6 @@
 // File: eternity/persist.cpp
 #include <eternity/persist.hpp>
+#include <functional>
 #include <initializer_list>
 #include <iterator>
 #include <memory>

--- a/python-wrapper/tests/test_01.py
+++ b/python-wrapper/tests/test_01.py
@@ -1,6 +1,5 @@
 import unittest
 import pytsa
-import pytest
 
 class MyTestCase(unittest.TestCase):
     def test_something(self):


### PR DESCRIPTION
the header `<functional>` is now required (I guess some third party headers removed it)
`pytest` is not part of the installation requirements and as a consequence, it is not automatically imported.