### PR TITLE
Update CMakeLists for build in Conda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,78 +1,24 @@
 cmake_minimum_required(VERSION 3.6)
-project(p4TSA)
-# The version number.
-
-if(NOT p4TSA_VERSION)
-  SET(p4TSA_VERSION_MAJOR 2)
-  SET(p4TSA_VERSION_MINOR 0)
-  SET(p4TSA_VERSION_PATCH 1)
-  SET(p4TSA_VERSION 2.0.1)
-endif(NOT p4TSA_VERSION)
+project(
+    p4TSA
+    LANGUAGES CXX
+    VERSION 2.0.1
+    DESCRIPTION "package for Time Series Analysis"
+)
 
 set(CMAKE_CXX_STANDARD 11)
 
-set(SOURCE_FILES
-        src/AR2.cpp
-        src/AR2Parcor.cpp
-        src/ArBurgEstimator.cpp
-        src/ArDurbinEstimator.cpp
-        src/Arma2Psd.cpp
-        src/Arma2TF.cpp
-        src/ARMAFilter.cpp
-        src/ARMAfit.cpp
-        src/BaseWindow.cpp
-        src/BLInterpolation.cpp
-        src/ButterworthFilter.cpp
-        src/Cholesky.cpp
-        src/ClusterizedEventFullFeatured.cpp
-        src/ComplexFFT.cpp
-        src/CreateDvector.cpp
-        src/DCT.cpp
-        src/DoubleWhitening.cpp
-        src/DST.cpp
-        src/eternity.cpp
-        src/EventDescription.cpp
-        src/EventFullFeatured.cpp
-        src/fparser.cpp
-        src/fpoptimizer.cpp
-        src/FrameIStream.cpp
-        src/FrameIChannel.cpp
-        src/eternity.cpp
-        src/FifoBuffer.cpp
-        src/IDCT.cpp
-        src/InverseRealFFT.cpp
-        src/LatticeFilter.cpp
-        src/LeastSquaresLattice.cpp
-        src/LSLfilter.cpp
-        src/LSLLearning.cpp
-        src/MYWE.cpp
-        src/tsaSerialize.cpp
-        src/tsaLog.cpp
-        src/tsaUtilityFunctions.cpp
-        src/NotchWidrow.cpp
-        src/Parcor2AR.cpp
-        src/RealFFT.cpp
-        src/RLSCanceler.cpp
-        src/SelectionOrderCriteria.cpp
-        src/VArma2TF.cpp
-        src/ViewUtil.cpp
-        src/WaveletThreshold.cpp
-        src/WaveletTransform.cpp
-        src/WavReconstruction.cpp
-        src/WDF2Classify.cpp
-        src/WDF2Reconstruct.cpp
-        src/WindowFactory.cpp)
-include_directories(include include/eternity $ENV{ENV_ROOT}/include $ENV{ENV_ROOT}/include/gsl) #$ENV{ENV_ROOT}/include/boost
+find_package(GSL REQUIRED)
+find_package(Boost REQUIRED)
 
+#Find Framel
+set(P4TSA_DEPENDENCIES "framel")
+pkg_check_modules(P4TSADEPS REQUIRED IMPORTED_TARGET ${P4TSA_DEPENDENCIES})
 
-link_directories($ENV{ENV_ROOT}/lib)
-link_libraries(gsl fftw3  gslcblas framel)
-add_library(p4TSA SHARED ${SOURCE_FILES})
-install (TARGETS p4TSA DESTINATION $ENV{ENV_ROOT}/lib)
-install (FILES include/tsa.hpp DESTINATION $ENV{ENV_ROOT}/include)
+add_subdirectory(src)
  
 # Add the cmake folder so the FindSphinx module is found
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
-if(DEFINED ENV{READTHEDOCS})
-  add_subdirectory ("docs")
-endif(DEFINED ENV{READTHEDOCS})
+if(BUILD_DOCS)
+  add_subdirectory (docs)
+endif(BUILD_DOCS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,63 @@
+set(SOURCE_FILES
+    AR2.cpp
+    AR2Parcor.cpp
+    ArBurgEstimator.cpp
+    ArDurbinEstimator.cpp
+    Arma2Psd.cpp
+    Arma2TF.cpp
+    ARMAFilter.cpp
+    ARMAfit.cpp
+    BaseWindow.cpp
+    BLInterpolation.cpp
+    ButterworthFilter.cpp
+    Cholesky.cpp
+    ClusterizedEventFullFeatured.cpp
+    ComplexFFT.cpp
+    CreateDvector.cpp
+    DCT.cpp
+    DoubleWhitening.cpp
+    DST.cpp
+    eternity.cpp
+    EventDescription.cpp
+    EventFullFeatured.cpp
+    fparser.cpp
+    fpoptimizer.cpp
+    FrameIStream.cpp
+    FrameIChannel.cpp
+    eternity.cpp
+    FifoBuffer.cpp
+    IDCT.cpp
+    InverseRealFFT.cpp
+    LatticeFilter.cpp
+    LeastSquaresLattice.cpp
+    LSLfilter.cpp
+    LSLLearning.cpp
+    MYWE.cpp
+    tsaSerialize.cpp
+    tsaLog.cpp
+    tsaUtilityFunctions.cpp
+    NotchWidrow.cpp
+    Parcor2AR.cpp
+    RealFFT.cpp
+    RLSCanceler.cpp
+    SelectionOrderCriteria.cpp
+    VArma2TF.cpp
+    ViewUtil.cpp
+    WaveletThreshold.cpp
+    WaveletTransform.cpp
+    WavReconstruction.cpp
+    WDF2Classify.cpp
+    WDF2Reconstruct.cpp
+    WindowFactory.cpp)
+
+
+#Create the library
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+
+#Add all the include directories to the target
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include )
+
+target_link_libraries(${PROJECT_NAME} PkgConfig::P4TSADEPS gsl fftw3  gslcblas)
+
+install(TARGETS p4TSA)
+install(FILES ${CMAKE_SOURCE_DIR}/include/tsa.hpp TYPE INCLUDE)

--- a/src/eternity.cpp
+++ b/src/eternity.cpp
@@ -26,10 +26,10 @@
 
 #include <eternity.hpp>
 
-#include <dynamic.cpp>
-#include <persist.cpp>
-#include <persist_xml.cpp>
-#include <xmlscanner.cpp>
+#include <eternity/dynamic.hpp>
+#include <eternity/persist.hpp>
+#include <eternity/persist_xml.hpp>
+#include <eternity/xmlscanner.hpp>
 
 
 #endif // ETERNITY_CPP 


### PR DESCRIPTION
This significantly changes the CMakeLists so the package can be built in Conda. It also automates the finding of the dependencies and removes the need for the ENV_ROOT environmental variable.

Once this is merged, I will propose another merge request also to build the Python bindings in CMake.